### PR TITLE
Jobs@ to .berlin

### DIFF
--- a/content/jobs/green-operations-marketing-manager.md
+++ b/content/jobs/green-operations-marketing-manager.md
@@ -80,7 +80,7 @@ In addition, we are committed to promoting diversity and inclusion in our organi
 &nbsp;
 
 ### How to apply
-Just shoot us an email at jobs@green-coding.org with a quick intro and why you would like to join our team.
+Just shoot us an email at jobs@green-coding.berlin with a quick intro and why you would like to join our team.
 
 Please also include a quick comment on your skills regarding the aforementioned skills.
 
@@ -162,7 +162,7 @@ Darüber hinaus setzen wir uns für die Förderung von Diversität und Inklusion
 &nbsp;
 
 ### WIE SIE SICH BEWERBEN KÖNNEN
-Schicken Sie uns einfach eine E-Mail an jobs@green-coding.org mit einer kurzen Vorstellung und warum Sie Teil unseres Teams werden möchten.
+Schicken Sie uns einfach eine E-Mail an jobs@green-coding.berlin mit einer kurzen Vorstellung und warum Sie Teil unseres Teams werden möchten.
 
 Bitte fügen Sie auch einen kurzen Kommentar zu Ihren Fähigkeiten bezüglich der oben genannten Fähigkeiten hinzu.
 

--- a/content/jobs/green-software-developer.md
+++ b/content/jobs/green-software-developer.md
@@ -108,7 +108,7 @@ During the onboarding however, which can take around 1-2 months, we usually star
 &nbsp;
 
 ### How to apply
-Just shoot us an email at jobs@green-coding.org with a quick intro and why you would like to join our team.
+Just shoot us an email at jobs@green-coding.berlin with a quick intro and why you would like to join our team.
 
 Please also include a quick comment on your skills regarding the aforementioned skills.
 

--- a/content/jobs/junior-green-software-developer.md
+++ b/content/jobs/junior-green-software-developer.md
@@ -87,7 +87,7 @@ During the onboarding however, which can take around 1-2 months, we usually star
 &nbsp;
 
 ### How to apply
-Just shoot us an email at jobs@green-coding.org with a quick intro and why you would like to join our team.
+Just shoot us an email at jobs@green-coding.berlin with a quick intro and why you would like to join our team.
 
 Please also include a quick comment on your skills regarding the aforementioned skills.
 

--- a/layouts/jobs/section.html
+++ b/layouts/jobs/section.html
@@ -7,7 +7,7 @@
     <section id="meetups" class="bg-one"><div id="ancla1"></div>
         <div class="section-one">
             <div class="title-one">Jobs</div>
-            <div class="data-content-one">Our current open positions. If your profession is in a different field and you would like to work with us: send us an initiative application to <a href="mailto:jobs@green-coding.org">jobs@green-coding.org</a></div>
+            <div class="data-content-one">Our current open positions. If your profession is in a different field and you would like to work with us: send us an initiative application to <a href="mailto:jobs@green-coding.berlin">jobs@green-coding.berlin</a></div>
             <div class="data-content-one">
                 {{ $paginator := (.Paginate ( where .Site.RegularPages "Type" "jobs" ) ) }}
                 {{ range $paginator.Pages.ByDate.Reverse }}

--- a/layouts/jobs/single.html
+++ b/layouts/jobs/single.html
@@ -14,7 +14,7 @@
             </div>
             <div class="btn-one-center">
                 <div class="btn-one">
-                    <span><a href="mailto:jobs@green-coding.org?subject=I would like to work with you :)" style="text-decoration: none; color: #fff;">Apply now via email</a></span>
+                    <span><a href="mailto:jobs@green-coding.berlin?subject=I would like to work with you :)" style="text-decoration: none; color: #fff;">Apply now via email</a></span>
                 </div>
             </div>
 


### PR DESCRIPTION
jobs@ moved to correct and new .berlin address

@ribalba Maybe there was a confusion. The .berlin email works fine and should be preferred, as this is the current display domain of the website.
LinkedIn does not understand .berlin TLD when submitting job ads. This is why we have it there as .org