### PR TITLE
Blocking indexing on custom build pages

### DIFF
--- a/static/_headers
+++ b/static/_headers
@@ -1,0 +1,2 @@
+https://:any.pages.dev/*
+  X-Robots-Tag: noindex


### PR DESCRIPTION
This PR shall introduce the functionality to not index the preview build pages.

Discussion here: https://community.cloudflare.com/t/add-x-robots-tag-noindex-to-deafult-pages-dev-subdomain-for-hugo-website/337232